### PR TITLE
Performance Improvements

### DIFF
--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -44,16 +44,16 @@ function Solver.new(config: ConfigType)
 end
 
 function Solver:Solve(CF: CFrame): RaycastParams | nil
-	local raycasts = table.create(self.ThicknessQuality)
+	local raycasts = table.create(self.ThicknessQuality) -- this is to avoid running two loops for no reason; two loops are O(n^2) in time complexity I believe
 	
 	local i = 0
 	
 	for t = 1, self.ThicknessQuality do
-		i = if i + 1 > self.Quality then self.Quality else i + 1 -- to avoid O(n^2)
+		i = if i + 1 > self.Quality then self.Quality else i + 1
 		
-		local angle = i * (FULL_CIRCLE / self.Quality)
+		local angle = i * (FULL_CIRCLE / self.Quality) -- (FULL_CIRCLE / self.Quality) this can be precomputed once the object has been created
 
-		local ang = t * (FULL_CIRCLE / 3)
+		local ang = t * (FULL_CIRCLE / 3) -- (FULL_CIRCLE / 3) can be precomputed once the module has loaded to avoid computation in literal frames
 		local newCFrame = (CF * CFrame.new(Vector3.yAxis * math.sin(ang) * (self.Size.X * 0.5)))
 
 		local position = (newCFrame * CFrame.new(Vector3.new(math.cos(angle) * 0.1, 0, math.sin(angle) * 0.1))).Position

--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -44,12 +44,12 @@ function Solver.new(config: ConfigType)
 end
 
 function Solver:Solve(CF: CFrame): RaycastParams | nil
-	local raycasts = table.create(self.ThicknessQuality) -- this is to avoid running two loops for no reason; two loops are O(n^2) in time complexity I believe
+	local raycasts = table.create(self.ThicknessQuality)
 	
 	local i = 0
 	
 	for t = 1, self.ThicknessQuality do
-		i = if i + 1 > self.Quality then self.Quality else i + 1
+		i = if i + 1 > self.Quality then self.Quality else i + 1 -- this is to avoid running two loops for no reason; two loops are O(n^2) in time complexity I believe
 		
 		local angle = i * (FULL_CIRCLE / self.Quality) -- (FULL_CIRCLE / self.Quality) this can be precomputed once the object has been created
 

--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -1,3 +1,10 @@
+--[[
+	
+	Author : IdleBrick
+	Contributors : Daw588, Sinlernick
+--]]
+
+
 local Workspace = game:GetService("Workspace")
 
 local FULL_CIRCLE = 2 * math.pi
@@ -17,61 +24,61 @@ type SolverType = {
 	RaycastParams : RaycastParams
 }
 
---[[
-	
-	Author : IdleBrick
-	Contributors : Daw588
-
---]]
 
 local Solver = {}
 Solver.__index = Solver
 
 function Solver.new(config: ConfigType)
 	local self = setmetatable({} :: SolverType, Solver)
-	
+
 	local raycastParams = RaycastParams.new()
 	raycastParams.FilterDescendantsInstances = config.Ignore
 	raycastParams.FilterType = Enum.RaycastFilterType.Blacklist
-	
+
 	self.RaycastParams = raycastParams
 	self.Quality = config.Quality
 	self.ThicknessQuality = config.ThicknessQuality
 	self.Size = config.Size
-	
+
 	return self
 end
 
 function Solver:Solve(CF: CFrame): RaycastParams | nil
-	local raycasts = {}
-
+	local raycasts = table.create(self.ThicknessQuality)
+	
+	local i = 0
+	
 	for t = 1, self.ThicknessQuality do
-		for i = 1, self.Quality do
-			local angle = i * (FULL_CIRCLE / self.Quality)
-			
-			local ang = t * (FULL_CIRCLE / 3)
-			local newCFrame = (CF * CFrame.new(Vector3.yAxis * math.sin(ang) * (self.Size.X * 0.5)))
-			
-			local position = (newCFrame * CFrame.new(Vector3.new(math.cos(angle) * 0.1, 0, math.sin(angle) * 0.1))).Position
-			local direction = (CFrame.new(position, newCFrame.Position) * CFRAME_ANGLES_AXIS_PI).LookVector
-			
-			local raycastResult = Workspace:Raycast(position, direction * ((self.Size.Y * 0.832) + 0.5), self.RaycastParams)
-			
-			if raycastResult then
-				if raycastResult.Instance then
-					table.insert(raycasts, raycastResult)
-				end
+		i = if i + 1 > self.Quality then self.Quality else i + 1 -- to avoid O(n^2)
+		
+		local angle = i * (FULL_CIRCLE / self.Quality)
+
+		local ang = t * (FULL_CIRCLE / 3)
+		local newCFrame = (CF * CFrame.new(Vector3.yAxis * math.sin(ang) * (self.Size.X * 0.5)))
+
+		local position = (newCFrame * CFrame.new(Vector3.new(math.cos(angle) * 0.1, 0, math.sin(angle) * 0.1))).Position
+		local direction = (CFrame.new(position, newCFrame.Position) * CFRAME_ANGLES_AXIS_PI).LookVector
+
+		local raycastResult = Workspace:Raycast(position, direction * ((self.Size.Y * 0.832) + 0.5), self.RaycastParams)
+		
+		
+		if raycastResult then
+			if raycastResult.Instance then
+				table.insert(raycasts, raycastResult)  -- not too sure why this is here, you can just get the first ray that intersected with an object
+				
 			end
 		end
 	end
 	
+
+
 	if next(raycasts) then
 		table.sort(raycasts, function(a, b)
-			return (a.Position - CF.Position).Magnitude < (b.Position - CF.Position).Magnitude
+			return (a.Position - CF.Position).Magnitude < (b.Position - CF.Position).Magnitude 
 		end)
 		return raycasts[1]
 	end
-	
+
 	return nil
 end
 


### PR DESCRIPTION
I have massively improved CC. 

The first optimization I have immediately made is to create the table with the size of `ThicknessQuality` before working on it:
![image](https://user-images.githubusercontent.com/111036791/184563982-5eda5bac-a7e2-444e-9c52-47b2a8d50fe7.png)
This is because every time you add an item to the table, it reallocates, but with this, it doesn't.

The second optimization I made is to remove the second loop in the `Solver` method, as this increases the time complexity for the whole algorithm and the time that the method overall took *(loops are kinda slow)*. Now the `i` increases by 1 every time the `t` increases if `i` is lower than `self.Quality`  

**EDIT:** I just noticed that the second optimization I made doesn't work as intended. I will search for another mechanism