### PR TITLE
Safety improvements and Removal of repetitive code

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -18,4 +18,4 @@ Creates a new CylindricalCast config. Returns [Metatable][rblx/Metatable]
 Casts the cylinder. Returns a table of [RaycastResult][rblx/RaycastResult]
 ### Syntax
 
-`CylindricalCast:Solve(CF: CFrame): {RaycastParams | nil}`
+`CylindricalCast:Solve(CF: CFrame): {RaycastResult} | nil`

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -18,4 +18,4 @@ Creates a new CylindricalCast config. Returns [Metatable][rblx/Metatable]
 Casts the cylinder. Returns a table of [RaycastResult][rblx/RaycastResult]
 ### Syntax
 
-`CylindricalCast:Solve(CF: CFrame): {RaycastParams} | nil`
+`CylindricalCast:Solve(CF: CFrame): {RaycastParams | nil}`

--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -60,7 +60,7 @@ function Solver.new(config: ConfigType)
 	return self
 end
 
-function Solver:Solve(CF: CFrame): {RaycastResult} | nil
+function Solver:Solve(CF: CFrame): {RaycastResult | nil}
 	local raycasts = self._rays
 	local length = self._rayLength 
 	
@@ -76,19 +76,13 @@ function Solver:Solve(CF: CFrame): {RaycastResult} | nil
 			local raycastResult = Workspace:Raycast(position, direction * length , self.RaycastParams)
 
 			if raycastResult then
-				if raycastResult.Instance then
-					table.insert(raycasts, raycastResult)
-				end
+				table.insert(raycasts, raycastResult)
 			end
 		end
 			
 	end
 
-	if next(raycasts) then
-		return raycasts
-	end
-
-	return nil
+	return raycasts
 end
 
 return Solver

--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -38,9 +38,9 @@ function Solver.new(config: ConfigType)
 	local raycastParams = RaycastParams.new()
 	raycastParams.FilterDescendantsInstances = config.Ignore
 	raycastParams.FilterType = Enum.RaycastFilterType.Blacklist
-
-	self.Size = config.Size
 	self.RaycastParams = raycastParams
+
+	self._Size = config.Size
 	self._Quality = config.Quality
 	self._ThicknessQuality = config.ThicknessQuality
 	self._CentreRadius = config.CentreRadius
@@ -64,9 +64,11 @@ function Solver:Solve(CF: CFrame): {RaycastResult | nil}
 	local raycasts = self._rays
 	local length = self._rayLength 
 	
+	local isIntersected = false
+	
 	table.clear(raycasts)
 
-	for _, CFRAME in self._newCFrames do
+	for index, CFRAME in self._newCFrames do
 		local newCFrame = (CF * CFRAME)
 		
 		for _, POSITION in self._positions do
@@ -76,13 +78,23 @@ function Solver:Solve(CF: CFrame): {RaycastResult | nil}
 			local raycastResult = Workspace:Raycast(position, direction * length , self.RaycastParams)
 
 			if raycastResult then
+				if isIntersected then
+				else
+					isIntersected = true
+				end
+				
 				table.insert(raycasts, raycastResult)
 			end
 		end
 			
 	end
+	
+	if isIntersected then
+		return raycasts
 
-	return raycasts
+	else
+		return nil
+	end
 end
 
 return Solver

--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -39,11 +39,11 @@ function Solver.new(config: ConfigType)
 	raycastParams.FilterDescendantsInstances = config.Ignore
 	raycastParams.FilterType = Enum.RaycastFilterType.Blacklist
 
-	self.RaycastParams = raycastParams
-	self.Quality = config.Quality
-	self.ThicknessQuality = config.ThicknessQuality
-	self.CentreRadius = config.CentreRadius
 	self.Size = config.Size
+	self.RaycastParams = raycastParams
+	self._Quality = config.Quality
+	self._ThicknessQuality = config.ThicknessQuality
+	self._CentreRadius = config.CentreRadius
 	self._rays = table.create(self.ThicknessQuality * self.Quality)
 	self._newCFrames = table.create(self.ThicknessQuality)
 	self._positions = table.create(self.Quality)

--- a/src/CylindricalCast.lua
+++ b/src/CylindricalCast.lua
@@ -47,6 +47,7 @@ function Solver.new(config: ConfigType)
 	self._rays = table.create(self.ThicknessQuality * self.Quality)
 	self._newCFrames = table.create(self.ThicknessQuality)
 	self._positions = table.create(self.Quality)
+	self._rayLength = (self.Size.Y * 0.832) + 0.5
 	
 	for i = 1, self.Quality do
 		local angle = i * (FULL_CIRCLE /  self.Quality)
@@ -61,7 +62,7 @@ end
 
 function Solver:Solve(CF: CFrame): {RaycastResult} | nil
 	local raycasts = self._rays
-	local s = (self.Size.Y * 0.832) + 0.5
+	local length = self._rayLength 
 	
 	table.clear(raycasts)
 
@@ -72,7 +73,7 @@ function Solver:Solve(CF: CFrame): {RaycastResult} | nil
 			local position = (newCFrame * POSITION).Position
 			local direction = (CFrame.new(position, newCFrame.Position) * CFRAME_ANGLES_AXIS_PI).LookVector
 
-			local raycastResult = Workspace:Raycast(position, direction * s , self.RaycastParams)
+			local raycastResult = Workspace:Raycast(position, direction * length , self.RaycastParams)
 
 			if raycastResult then
 				if raycastResult.Instance then


### PR DESCRIPTION
Here is list of what I have done.

https://github.com/IdleBrickRBLX/CylindricalCast/commit/a89328950e3c018d6299c66335bd285212365387 -  I have added an underscore `_` before Quality, Thickness Quality and CentreRadius showing that they shouldn't be used publicly as they will have no effect due to pre-computation.

https://github.com/IdleBrickRBLX/CylindricalCast/commit/cc689c70ad8ea2bb8a8bc6274115daed437d7dc1 - I have changed the variable `s` name to "_rayLength" and pre-computed it in `.new()` just like it's sisters.

https://github.com/IdleBrickRBLX/CylindricalCast/commit/da586da5d3eaeb2f9aef3ecf23220b54504d8716 - I have removed the part where it was checking if there was an instance in the `RaycastResult` object, as `workspace:Raycast()` only returns raycastresult when it actually hits something. I also removed the part where it was checking if there was an element in the raycasts table, although I am actually considering if it would be better if we're to have a boolean variable to indicate if an object was hit and return the table if so, and nil if not; this is probably the most performant way to do this and doesn't include any "searching" for results. *(the # operrator does a binary search too If I remember correctly)*